### PR TITLE
Map a missed command: ___kubectl_get_resource

### DIFF
--- a/kubectl_fzf.sh
+++ b/kubectl_fzf.sh
@@ -2,6 +2,7 @@ export KUBECTL_FZF_CACHE="/tmp/kubectl_fzf_cache"
 eval "`declare -f __kubectl_parse_get | sed '1s/.*/_&/'`"
 eval "`declare -f __kubectl_parse_resource | sed '1s/.*/_&/'`"
 eval "`declare -f __kubectl_get_containers | sed '1s/.*/_&/'`"
+eval "`declare -f __kubectl_get_resource | sed '1s/.*/_&/'`"
 KUBECTL_FZF_EXCLUDE=${KUBECTL_FZF_EXCLUDE:-}
 KUBECTL_FZF_OPTIONS=(-1 --header-lines=2 --layout reverse -e --no-hscroll --no-sort)
 


### PR DESCRIPTION
`__kubectl_get_resource` raise an error if `cache_builder` did not run.

input:

```
kubectl get po <TAB>
```

output:

```
__kubectl_get_resource:6: command not found: ___kubectl_get_resource
```
