### PR TITLE
fix notation on _fzf_check_for_endpoints

### DIFF
--- a/kubectl_fzf.plugin.zsh
+++ b/kubectl_fzf.plugin.zsh
@@ -22,7 +22,7 @@ _fzf_check_for_endpoints()
     if [[ -s "$endpoint_file" ]]; then
         local cached_ip; cached_ip=$(cat "$endpoint_file")
         if [[ "$cached_ip" == "No service" ]]; then
-            local mtime; mtime=$(stat +mtime "$endpoint_file")
+            local mtime; mtime=$(stat -c %Y "$endpoint_file")
             local current; current=$(date +%s)
             if [[ $((current - mtime)) -lt 3600 ]]; then
                 return


### PR DESCRIPTION
It had given that error while I was trying `-n kube-sy` and <TAB>
error:
` % kubectl get pods -n kube-systat: cannot stat ‘+mtime’: No such file or directory
_fzf_check_for_endpoints:9: bad math expression: operand expected at ‘/tmp/ku...'
stem
`
just simple notation, thanks for this nice tool