### PR TITLE
Bring helm chart up to date, mandate specifying contextName with helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can deploy the cache builder as a pod in your cluster.
 
 ```shell
 
-helm template --namespace myns --set image.cache_builder.tag=1.0.11 --set toleration=aToleration . | kubectl apply -f -
+helm template --namespace myns --set image.cache_builder.tag=1.0.11 --set toleration=aToleration . --set contextName=(your kubectl context) | kubectl apply -f -
 ```
 
 You can check the latest image version [here](https://cloud.docker.com/repository/docker/bonnefoa/kubectl-fzf/general).
@@ -155,7 +155,7 @@ By default, it will use the port 80.
 You can change it by deploying the chart with a different port value and using `KUBECTL_FZF_RSYNC_PORT`:
 
 ```shell
-helm template --namespace myns --set port=873 . | kubectl apply -f -
+helm template --namespace myns --set port=873 . --set contextName=(your kubectl context) | kubectl apply -f -
 export KUBECTL_FZF_RSYNC_PORT=873
 ```
 

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: kubectl-fzf
 description: Chart for kubectl-fzf cache builder
-version: 0.2.0
+version: 1.0.0

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v2
 name: kubectl-fzf
 description: Chart for kubectl-fzf cache builder
-version: 0.1.0
+version: 0.2.0

--- a/k8s/templates/deployments.yaml
+++ b/k8s/templates/deployments.yaml
@@ -48,7 +48,7 @@ spec:
             cpu: {{ $.Values.resources.cache_builder.cpu }}
         args:
           - --in-cluster
-          - --cluster-name=$(K8S_CLUSTER_INFRA_DOMAIN)
+          - --cluster-name={{ .Values.contextName }}
 
       - name: rsyncd
         image: {{ $.Values.image.rsyncd.name }}:{{ $.Values.image.rsyncd.tag }}

--- a/k8s/templates/services.yaml
+++ b/k8s/templates/services.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ $.Chart.Name }}
     chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
 spec:
-  clusterIP: None
   ports:
   - name: rsync
     port: {{ $.Values.port }}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -3,10 +3,12 @@ port: 80
 docker:
   pullPolicy: IfNotPresent
 
+contextName: default
+
 image:
   cache_builder:
     name: bonnefoa/kubectl-fzf
-    tag: v1.0.11
+    tag: 3.0.0
   rsyncd:
     name: eeacms/rsync
     tag: 2.1


### PR DESCRIPTION
- You must specify contextName when installing with helm
- Add missing apiVersion in chart.yaml
- remove clusterIP which conflicts if a helm upgrade is performed
- Set tag to 3.0.0 which I assume will be built when this is released