### PR TITLE
fix: follow same logic for KUBECONF as normal kubectl

### DIFF
--- a/convert-bash-to-zsh.sh
+++ b/convert-bash-to-zsh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sed \
         -e 's/declare -F/whence -w/' \

--- a/pkg/util/cluster_conf.go
+++ b/pkg/util/cluster_conf.go
@@ -66,8 +66,5 @@ func (c *ClusterCliConf) GetClientConfigAndCluster() (*rest.Config, string) {
 	cfg, err := clientcmd.BuildConfigFromKubeconfigGetter("", configPath.GetStartingConfig)
 	FatalIf(err)
 
-	//fmt.Printf("%+v\n", cfg)
-	//os.Exit(1)
-
 	return cfg, c.ClusterName
 }

--- a/pkg/util/cluster_conf.go
+++ b/pkg/util/cluster_conf.go
@@ -2,10 +2,6 @@ package util
 
 import (
 	"flag"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
 	"github.com/spf13/viper"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -16,15 +12,12 @@ type ClusterCliConf struct {
 	InCluster   bool
 	CacheDir    string
 	Kubeconfig  string
+	IsExplicit  bool
 }
 
 func SetClusterConfFlags() {
-	if home := os.Getenv("HOME"); home != "" {
-		flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	}
-
+	flag.String("kubeconfig", clientcmd.RecommendedHomeFile, "(optional) absolute path to the kubeconfig file, KUBECONFIG variable has higher priority)")
+	flag.Bool("explicit-config", false, "Configure config loader to use file specified by 'kubeconfig' flag explicitly.")
 	flag.String("cache-dir", "/tmp/kubectl_fzf_cache/", "Cache dir location.")
 	flag.String("cluster-name", "incluster", "The cluster name. Needed for cross-cluster completion.")
 	flag.Bool("in-cluster", false, "Use in-cluster configuration")
@@ -35,6 +28,7 @@ func GetClusterCliConf() ClusterCliConf {
 	c.InCluster = viper.GetBool("in-cluster")
 	c.ClusterName = viper.GetString("cluster-name")
 	c.Kubeconfig = viper.GetString("kubeconfig")
+	c.IsExplicit = viper.GetBool("explicit-config")
 	c.CacheDir = viper.GetString("cache-dir")
 	return c
 }
@@ -54,16 +48,26 @@ func (c *ClusterCliConf) GetClientConfigAndCluster() (*rest.Config, string) {
 		return restConfig, c.ClusterName
 	}
 
-	configInBytes, err := ioutil.ReadFile(c.Kubeconfig)
-	FatalIf(err)
-	clientConfig, err := clientcmd.NewClientConfigFromBytes(configInBytes)
-	FatalIf(err)
+	configPath := &clientcmd.PathOptions{
+		GlobalFile:   c.Kubeconfig,
+		EnvVar:       clientcmd.RecommendedConfigPathEnvVar,
+		LoadingRules: clientcmd.NewDefaultClientConfigLoadingRules(),
+	}
 
+	if c.IsExplicit {
+		configPath.LoadingRules.ExplicitPath = c.Kubeconfig
+	}
+
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(configPath.LoadingRules, &clientcmd.ConfigOverrides{})
 	rawConfig, err := clientConfig.RawConfig()
+	c.ClusterName = rawConfig.CurrentContext
 	FatalIf(err)
-	cluster := rawConfig.CurrentContext
 
-	cfg, err := clientcmd.BuildConfigFromFlags("", c.Kubeconfig)
+	cfg, err := clientcmd.BuildConfigFromKubeconfigGetter("", configPath.GetStartingConfig)
 	FatalIf(err)
-	return cfg, cluster
+
+	//fmt.Printf("%+v\n", cfg)
+	//os.Exit(1)
+
+	return cfg, c.ClusterName
 }

--- a/test_completion.zsh
+++ b/test_completion.zsh
@@ -1,4 +1,4 @@
-#!/usr/bin/zsh
+#!/usr/bin/env zsh
 
 . kubectl_completion.zsh
 BASH_COMP_DEBUG_FILE="/tmp/log"


### PR DESCRIPTION
This one allows to load multiple configs when `KUBECONF` defined with multiple configs in it.   
It uses native api with `clientcmd.PathOptions` and load configuration on next order:    

1.   `KUBECONF`  -  if not empty
2.   `$HOME/.kube/config` - if not set differently with `-kubeconf`

Also added option to ignore `KUBECONF` and load explicitly configuration from config defined with `-kubeconf` flag.
