### PR TITLE
make fzf options configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ By default, the local port used for the port-forward is 8080. You can override i
 KUBECTL_FZF_PORT_FORWARD_LOCAL_PORT=8081
 ```
 
+You can override FZF arguments using an environment variable:
+```
+KUBECTL_FZF_ARGS="-1 --header-lines=2 --layout reverse --exact --no-hscroll --no-sort --cycle"
+```
+
 # Troubleshooting
 
 ## Debug kubectl-fzf-completion

--- a/cmd/kubectl-fzf-completion/main.go
+++ b/cmd/kubectl-fzf-completion/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/pprof"
+	"strings"
 
 	"github.com/bonnefoa/kubectl-fzf/v3/internal/completion"
 	"github.com/bonnefoa/kubectl-fzf/v3/internal/fetcher"
@@ -29,6 +30,7 @@ var (
 	gitBranch = "unknown"
 	goVersion = "unknown"
 	buildDate = "unknown"
+	fzfArgs   = []string{"-1", "--header-lines=2", "--layout", "reverse", "--exact", "--no-hscroll", "--no-sort", "--cycle"}
 )
 
 func versionFun(cmd *cobra.Command, args []string) {
@@ -88,8 +90,11 @@ func completeFun(cmd *cobra.Command, cmdArgs []string) {
 	}
 	formattedComps := completionResults.GetFormattedOutput()
 
+	if args, exist := os.LookupEnv("KUBECTL_FZF_ARGS"); exist {
+		fzfArgs = strings.Split(args, " ")
+	}
 	query := completion.ExtractQueryFromArgs(args)
-	fzfResult, err := fzf.CallFzf(formattedComps, query)
+	fzfResult, err := fzf.CallFzf(formattedComps, query, fzfArgs)
 	if err != nil {
 		if e, ok := err.(fzf.InterruptedCommandError); ok {
 			logrus.Infof("Fzf was interrupted: %s", e)

--- a/internal/fzf/call_fzf.go
+++ b/internal/fzf/call_fzf.go
@@ -34,7 +34,7 @@ func setCompsInStdin(cmd *exec.Cmd, comps string) error {
 	return nil
 }
 
-func CallFzf(comps string, query string) (string, error) {
+func CallFzf(comps string, query string, fzfArgs []string) (string, error) {
 	var result strings.Builder
 	header := strings.Split(comps, "\n")[1]
 	// Leave an additional line for overflow
@@ -43,8 +43,7 @@ func CallFzf(comps string, query string) (string, error) {
 	previewWindow := fmt.Sprintf("--preview-window=down:%d", numFields)
 	previewCmd := fmt.Sprintf("echo -e \"%s\n{}\" | sed -e \"s/'//g\" | awk '(NR==1){for (i=1; i<=NF; i++) a[i]=$i} (NR==2){for (i in a) {printf a[i] \": \" $i \"\\n\"} }' | column -t | fold -w $COLUMNS", header)
 
-	// TODO Make fzf options configurable
-	fzfArgs := []string{"-1", "--header-lines=2", "--layout", "reverse", "-e", "--no-hscroll", "--no-sort", "--cycle", "-q", query, previewWindow, "--preview", previewCmd}
+	fzfArgs = append(fzfArgs, []string{"-q", query, previewWindow, "--preview", previewCmd}...)
 	logrus.Infof("fzf args: %+v", fzfArgs)
 	cmd := exec.Command("fzf", fzfArgs...)
 	cmd.Stdout = &result


### PR DESCRIPTION
Here is a pull request which adds support for configurable `fzf` arguments using the `KUBECTL_FZF_ARGS` environment variable.

This allow user to change define arguments sent to fzf executable.
As an example I now use the following fzf args in order to benefit disable exact match and enable sorting.

```shell
export KUBECTL_FZF_ARGS="-1 --header-lines=2 --layout reverse --no-hscroll --cycle"
```